### PR TITLE
fix(init): properly check if SDKMAN_DIR is set

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,5 +1,5 @@
 if type -q fenv
-    set -q $SDKMAN_DIR
+    set -q SDKMAN_DIR
     or set -gx SDKMAN_DIR ~/.sdkman
     set -g sdkman_prefix $SDKMAN_DIR
 


### PR DESCRIPTION
without this, you get the following error:
```
bash: /bin/sdkman-init.sh: No such file or directory
```