### PR TITLE
autoenv support

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -4,4 +4,27 @@ if type -q fenv
     set -g sdkman_prefix $SDKMAN_DIR
 
     fenv "source $sdkman_prefix/bin/sdkman-init.sh"
+
+  if set -q SDKMAN_DIR && grep -q "^sdkman_auto_env=true" "$SDKMAN_DIR/etc/config"
+    function __omf_sdk_sdkman_auto_env --on-variable PWD
+  
+      # chdir from current SDKMAN_ENV dirtree outside
+      # or 
+      # chdir into dir with .sdkmanrc that doesn't match the current SDKMAN_ENV root 
+      if begin; test -n $SDKMAN_ENV && not string match -q "$SDKMAN_ENV/**" "$PWD/"; end \
+        || begin; test "$SDKMAN_OLD_PWD" != "$PWD" && test "$SDKMAN_ENV" != "$PWD" && test -f ".sdkmanrc"; end
+
+        # runs SDKMAN's chdir hook, results in `sdk env clear` (if there was a previous SDKMAN_ENV) and `sdk env` (if there is a new .sdkmanrc)
+        fenv "source $sdkman_prefix/bin/sdkman-init.sh && export SDKMAN_ENV"
+    
+        # there was `sdk env clear` without `sdk env`
+        if not test -f ".sdkmanrc"
+          # unset SDKMAN_ENV as fenv can't currently unset variables
+          set -eg SDKMAN_ENV
+        end
+      end
+  
+      set -gx SDKMAN_OLD_PWD "$PWD"
+    end
+  end
 end

--- a/init.fish
+++ b/init.fish
@@ -5,7 +5,7 @@ if type -q fenv
 
     fenv "source $sdkman_prefix/bin/sdkman-init.sh"
 
-  if set -q SDKMAN_DIR && grep -q "^sdkman_auto_env=true" "$SDKMAN_DIR/etc/config"
+  if grep -q "^sdkman_auto_env=true" "$sdkman_prefix/etc/config"
     function __omf_sdk_sdkman_auto_env --on-variable PWD
   
       # chdir from current SDKMAN_ENV dirtree outside


### PR DESCRIPTION
This adds SDKMAN's autoenv  support. 

It is inspired by SDKMAN's own chdir hook [functions](https://github.com/sdkman/sdkman-cli/blob/460079381e8e9cce23aa03793607bbf92ba89206/src/main/bash/sdkman-init.sh#L159C1-L159C1). But there is no need to copy all the executed command from the original hook as it is run by `sdkman-init.sh` anyway, so I just run the script and let it work it's magic. The rest is to workaround `fenv`'s limitation and not to run the `sdkman-init.sh` script when unnecessary.

I'm new to fish, so feel free to suggest improvements.